### PR TITLE
사칙연산 버튼 배치  변경하기

### DIFF
--- a/calculator_main.py
+++ b/calculator_main.py
@@ -10,9 +10,10 @@ class Main(QDialog):
         main_layout = QVBoxLayout()
 
         ### 각 위젯을 배치할 레이아웃을 미리 만들어 둠
-        layout_operation = QHBoxLayout()
-        layout_clear_equal = QHBoxLayout()
-        layout_number = QGridLayout()
+        #layout_operation = QHBoxLayout()
+        #layout_clear_equal = QHBoxLayout()
+        #layout_number = QGridLayout()
+        layout_button = QGridLayout()
         layout_equation_solution = QFormLayout()
 
         ### 수식 입력과 답 출력을 위한 LineEdit 위젯 생성
@@ -29,7 +30,7 @@ class Main(QDialog):
         button_plus = QPushButton("+")
         button_minus = QPushButton("-")
         button_product = QPushButton("x")
-        button_division = QPushButton("/")
+        button_division = QPushButton("÷")
 
         ### 사칙연산 버튼을 클릭했을 때, 각 사칙연산 부호가 수식창에 추가될 수 있도록 시그널 설정
         button_plus.clicked.connect(lambda state, operation = "+": self.button_operation_clicked(operation))
@@ -38,25 +39,25 @@ class Main(QDialog):
         button_division.clicked.connect(lambda state, operation = "/": self.button_operation_clicked(operation))
 
         ### 사칙연산 버튼을 layout_operation 레이아웃에 추가
-        layout_operation.addWidget(button_plus)
-        layout_operation.addWidget(button_minus)
-        layout_operation.addWidget(button_product)
-        layout_operation.addWidget(button_division)
+        layout_button.addWidget(button_plus, 4, 3)
+        layout_button.addWidget(button_minus, 3, 3)
+        layout_button.addWidget(button_product, 2, 3)
+        layout_button.addWidget(button_division, 1, 3)
 
         ### =, clear, backspace 버튼 생성
         button_equal = QPushButton("=")
-        button_clear = QPushButton("Clear")
+        #button_clear = QPushButton("Clear")
         button_backspace = QPushButton("Backspace")
 
         ### =, clear, backspace 버튼 클릭 시 시그널 설정
         button_equal.clicked.connect(self.button_equal_clicked)
-        button_clear.clicked.connect(self.button_clear_clicked)
+        #button_clear.clicked.connect(self.button_clear_clicked)
         button_backspace.clicked.connect(self.button_backspace_clicked)
 
         ### =, clear, backspace 버튼을 layout_clear_equal 레이아웃에 추가
-        layout_clear_equal.addWidget(button_clear)
-        layout_clear_equal.addWidget(button_backspace)
-        layout_clear_equal.addWidget(button_equal)
+        #layout_clear_equal.addWidget(button_clear)
+        layout_button.addWidget(button_backspace, 0, 3)
+        layout_button.addWidget(button_equal, 5, 3)
 
         ### 숫자 버튼 생성하고, layout_number 레이아웃에 추가
         ### 각 숫자 버튼을 클릭했을 때, 숫자가 수식창에 입력 될 수 있도록 시그널 설정
@@ -67,18 +68,18 @@ class Main(QDialog):
                                                        self.number_button_clicked(num))
             if number >0:
                 x,y = divmod(number-1, 3)
-                layout_number.addWidget(number_button_dict[number], x, y)
+                layout_button.addWidget(number_button_dict[number], x+2, y)
             elif number==0:
-                layout_number.addWidget(number_button_dict[number], 3, 1)
+                layout_button.addWidget(number_button_dict[number], 5, 1)
 
         ### 소숫점 버튼과 00 버튼을 입력하고 시그널 설정
         button_dot = QPushButton(".")
         button_dot.clicked.connect(lambda state, num = ".": self.number_button_clicked(num))
-        layout_number.addWidget(button_dot, 3, 2)
+        layout_button.addWidget(button_dot, 5, 2)
 
         button_double_zero = QPushButton("00")
         button_double_zero.clicked.connect(lambda state, num = "00": self.number_button_clicked(num))
-        layout_number.addWidget(button_double_zero, 3, 0)
+        layout_button.addWidget(button_double_zero, 5, 0)
 
         ### 추가 연산 기능 버튼 생성
         button_remain = QPushButton("%")
@@ -89,18 +90,18 @@ class Main(QDialog):
         button_root = QPushButton("²√x")
         
         ### 추가 연산 기능 버튼을 layout_operation 레이아웃에 추가
-        layout_operation.addWidget(button_remain)
-        layout_operation.addWidget(button_CE)
-        layout_operation.addWidget(button_C)
-        layout_operation.addWidget(button_reciprocal)
-        layout_operation.addWidget(button_square)
-        layout_operation.addWidget(button_root)
+        layout_button.addWidget(button_remain, 0, 0)
+        layout_button.addWidget(button_CE, 0, 1)
+        layout_button.addWidget(button_C, 0, 2)
+        layout_button.addWidget(button_reciprocal, 1, 0)
+        layout_button.addWidget(button_square, 1, 1)
+        layout_button.addWidget(button_root, 1, 2)
         
         ### 각 레이아웃을 main_layout 레이아웃에 추가
         main_layout.addLayout(layout_equation_solution)
-        main_layout.addLayout(layout_operation)
-        main_layout.addLayout(layout_clear_equal)
-        main_layout.addLayout(layout_number)
+        main_layout.addLayout(layout_button)
+        #main_layout.addLayout(layout_clear_equal)
+        #main_layout.addLayout(layout_number)
 
         self.setLayout(main_layout)
         self.show()
@@ -123,9 +124,9 @@ class Main(QDialog):
         solution = eval(equation)
         self.solution.setText(str(solution))
 
-    def button_clear_clicked(self):
-        self.equation.setText("")
-        self.solution.setText("")
+    #def button_clear_clicked(self):
+        #self.equation.setText("")
+        #self.solution.setText("")
 
     def button_backspace_clicked(self):
         equation = self.equation.text()


### PR DESCRIPTION
사칙연산 버튼을 비롯해 BackSpace버튼, Equals버튼, 추가 연산 기능 버튼들과 숫자 버튼들의 배치를 윈도우 표준 계산기와 같게 변경했다.
layout_equation_solution을 뺀 나머지 레이아웃들을 없애고 layout_button을 만들어 각 버튼들을 배치해준 다음 layout_equation_solution과
layout_button을 main_layout에 추가하였다.